### PR TITLE
Breakfix revert SQS string error constants

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,6 @@
 ### SDK Features
+* `service/sqs`: BREAKFIX: Revert SQS error constants to original state
+  * Values for SQS error constants were incorrectly changed. This reverts them back.
 
 ### SDK Enhancements
 

--- a/private/model/api/codegentest/service/awsquerycompatible/awsquerycompatible_test.go
+++ b/private/model/api/codegentest/service/awsquerycompatible/awsquerycompatible_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 func TestAWSQuery(t *testing.T) {
@@ -31,7 +32,7 @@ func TestAWSQuery(t *testing.T) {
 		"when header is present": {
 			statusCode:      400,
 			responseBody:    strings.NewReader(`{"__type":"com.amazonaws.awsquerycompatible#QueueDeletedRecently", "message":"Some user-visible message"}`),
-			expectErrorCode: "AWS.SimpleQueueService.QueueDeletedRecently",
+			expectErrorCode: sqs.ErrCodeQueueDeletedRecently,
 			headers:         map[string]string{"x-amzn-query-error": "AWS.SimpleQueueService.QueueDeletedRecently;Sender"},
 		},
 		"for unmodeled error code": {

--- a/service/sqs/errors.go
+++ b/service/sqs/errors.go
@@ -9,22 +9,22 @@ import (
 const (
 
 	// ErrCodeBatchEntryIdsNotDistinct for service response error code
-	// "BatchEntryIdsNotDistinct".
+	// "AWS.SimpleQueueService.BatchEntryIdsNotDistinct".
 	//
 	// Two or more batch entries in the request have the same Id.
-	ErrCodeBatchEntryIdsNotDistinct = "BatchEntryIdsNotDistinct"
+	ErrCodeBatchEntryIdsNotDistinct = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct"
 
 	// ErrCodeBatchRequestTooLong for service response error code
-	// "BatchRequestTooLong".
+	// "AWS.SimpleQueueService.BatchRequestTooLong".
 	//
 	// The length of all the messages put together is more than the limit.
-	ErrCodeBatchRequestTooLong = "BatchRequestTooLong"
+	ErrCodeBatchRequestTooLong = "AWS.SimpleQueueService.BatchRequestTooLong"
 
 	// ErrCodeEmptyBatchRequest for service response error code
-	// "EmptyBatchRequest".
+	// "AWS.SimpleQueueService.EmptyBatchRequest".
 	//
 	// The batch request doesn't contain any entries.
-	ErrCodeEmptyBatchRequest = "EmptyBatchRequest"
+	ErrCodeEmptyBatchRequest = "AWS.SimpleQueueService.EmptyBatchRequest"
 
 	// ErrCodeInvalidAddress for service response error code
 	// "InvalidAddress".
@@ -45,10 +45,10 @@ const (
 	ErrCodeInvalidAttributeValue = "InvalidAttributeValue"
 
 	// ErrCodeInvalidBatchEntryId for service response error code
-	// "InvalidBatchEntryId".
+	// "AWS.SimpleQueueService.InvalidBatchEntryId".
 	//
 	// The Id of a batch entry in a batch request doesn't abide by the specification.
-	ErrCodeInvalidBatchEntryId = "InvalidBatchEntryId"
+	ErrCodeInvalidBatchEntryId = "AWS.SimpleQueueService.InvalidBatchEntryId"
 
 	// ErrCodeInvalidIdFormat for service response error code
 	// "InvalidIdFormat".
@@ -119,10 +119,10 @@ const (
 	ErrCodeKmsThrottled = "KmsThrottled"
 
 	// ErrCodeMessageNotInflight for service response error code
-	// "MessageNotInflight".
+	// "AWS.SimpleQueueService.MessageNotInflight".
 	//
 	// The specified message isn't in flight.
-	ErrCodeMessageNotInflight = "MessageNotInflight"
+	ErrCodeMessageNotInflight = "AWS.SimpleQueueService.MessageNotInflight"
 
 	// ErrCodeOverLimit for service response error code
 	// "OverLimit".
@@ -134,33 +134,33 @@ const (
 	ErrCodeOverLimit = "OverLimit"
 
 	// ErrCodePurgeQueueInProgress for service response error code
-	// "PurgeQueueInProgress".
+	// "AWS.SimpleQueueService.PurgeQueueInProgress".
 	//
 	// Indicates that the specified queue previously received a PurgeQueue request
 	// within the last 60 seconds (the time it can take to delete the messages in
 	// the queue).
-	ErrCodePurgeQueueInProgress = "PurgeQueueInProgress"
+	ErrCodePurgeQueueInProgress = "AWS.SimpleQueueService.PurgeQueueInProgress"
 
 	// ErrCodeQueueDeletedRecently for service response error code
-	// "QueueDeletedRecently".
+	// "AWS.SimpleQueueService.QueueDeletedRecently".
 	//
 	// You must wait 60 seconds after deleting a queue before you can create another
 	// queue with the same name.
-	ErrCodeQueueDeletedRecently = "QueueDeletedRecently"
+	ErrCodeQueueDeletedRecently = "AWS.SimpleQueueService.QueueDeletedRecently"
 
 	// ErrCodeQueueDoesNotExist for service response error code
-	// "QueueDoesNotExist".
+	// "AWS.SimpleQueueService.NonExistentQueue".
 	//
 	// The specified queue doesn't exist.
-	ErrCodeQueueDoesNotExist = "QueueDoesNotExist"
+	ErrCodeQueueDoesNotExist = "AWS.SimpleQueueService.NonExistentQueue"
 
 	// ErrCodeQueueNameExists for service response error code
-	// "QueueNameExists".
+	// "QueueAlreadyExists".
 	//
 	// A queue with this name already exists. Amazon SQS returns this error only
 	// if the request includes attributes whose values differ from those of the
 	// existing queue.
-	ErrCodeQueueNameExists = "QueueNameExists"
+	ErrCodeQueueNameExists = "QueueAlreadyExists"
 
 	// ErrCodeReceiptHandleIsInvalid for service response error code
 	// "ReceiptHandleIsInvalid".
@@ -193,16 +193,16 @@ const (
 	ErrCodeResourceNotFoundException = "ResourceNotFoundException"
 
 	// ErrCodeTooManyEntriesInBatchRequest for service response error code
-	// "TooManyEntriesInBatchRequest".
+	// "AWS.SimpleQueueService.TooManyEntriesInBatchRequest".
 	//
 	// The batch request contains more entries than permissible.
-	ErrCodeTooManyEntriesInBatchRequest = "TooManyEntriesInBatchRequest"
+	ErrCodeTooManyEntriesInBatchRequest = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest"
 
 	// ErrCodeUnsupportedOperation for service response error code
-	// "UnsupportedOperation".
+	// "AWS.SimpleQueueService.UnsupportedOperation".
 	//
 	// Error code 400. Unsupported operation.
-	ErrCodeUnsupportedOperation = "UnsupportedOperation"
+	ErrCodeUnsupportedOperation = "AWS.SimpleQueueService.UnsupportedOperation"
 )
 
 var exceptionFromCode = map[string]func(protocol.ResponseMetadata) error{


### PR DESCRIPTION
On 11/8/2023, the values for SQS string error constants were incorrectly changed when SQS switched protocols from AWS Query to AWS JSON.

This PR reverts SQS string error constants back to their old values on 11/7/2023

Testing:
correctness can be verified by viewing the diff between the commit ID on 11/7/2023 and the latest commit ID on this PR branch
```
git diff b87529cf2 b601e1966 -- service/sqs/errors.go
```

Fixes: https://github.com/aws/aws-sdk-go/issues/5090