### PR TITLE
drop s3express blurb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,9 +109,7 @@ Release v1.48.7 (2023-11-28)
 * `service/qbusiness`: Updates service API, documentation, paginators, and examples
 * `service/qconnect`: Updates service API, documentation, paginators, and examples
 * `service/s3`: Updates service API, documentation, paginators, and examples
-  * Adds support for S3 Express One Zone.
 * `service/s3control`: Updates service API and documentation
-  * Adds support for S3 Express One Zone, and InvocationSchemaVersion 2.0 for S3 Batch Operations.
 
 Release v1.48.6 (2023-11-28)
 ===


### PR DESCRIPTION
Drop s3express blurb since v1 didn't get support.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
