### PR TITLE
Add log level check to gate IMDSv1 fallback warning

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+The logging behavior in `aws/ec2metadata/token_provider.go` was updated: warnings about falling back to IMDSv1 are now logged only when LogLevel is set to `LogDebugWithDeprecated`. This change prevents unnecessary warnings when LogLevel is set to suppress messages.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,4 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-    The logging behavior in `aws/ec2metadata/token_provider.go` was updated: warnings about falling back to IMDSv1 are now logged only when LogLevel is set to `LogDebugWithDeprecated`. This change prevents unnecessary warnings when LogLevel is set to suppress messages.
+* The logging behavior in `aws/ec2metadata/token_provider.go` was updated: warnings about falling back to IMDSv1 are now logged only when LogLevel is set to `LogDebugWithDeprecated`.
+  * This change prevents unnecessary warnings when LogLevel is set to suppress messages.  

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,4 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-The logging behavior in `aws/ec2metadata/token_provider.go` was updated: warnings about falling back to IMDSv1 are now logged only when LogLevel is set to `LogDebugWithDeprecated`. This change prevents unnecessary warnings when LogLevel is set to suppress messages.
+    The logging behavior in `aws/ec2metadata/token_provider.go` was updated: warnings about falling back to IMDSv1 are now logged only when LogLevel is set to `LogDebugWithDeprecated`. This change prevents unnecessary warnings when LogLevel is set to suppress messages.

--- a/aws/ec2metadata/token_provider.go
+++ b/aws/ec2metadata/token_provider.go
@@ -2,6 +2,7 @@ package ec2metadata
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -65,7 +66,9 @@ func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
 			switch requestFailureError.StatusCode() {
 			case http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed:
 				atomic.StoreUint32(&t.disabled, 1)
-				t.client.Config.Logger.Log(fmt.Sprintf("WARN: failed to get session token, falling back to IMDSv1: %v", requestFailureError))
+				if t.client.Config.LogLevel.Matches(aws.LogDebugWithDeprecated) {
+					t.client.Config.Logger.Log(fmt.Sprintf("WARN: failed to get session token, falling back to IMDSv1: %v", requestFailureError))
+				}
 			case http.StatusBadRequest:
 				r.Error = requestFailureError
 			}


### PR DESCRIPTION
**Description**
Addresses #5116 
This PR updates the logging behavior in the EC2Metadata token provider (`token_provider.go`). It modifies the conditions under which the warning message about falling back to IMDSv1 is logged.

**Changes**
The warning _"WARN: failed to get session token, falling back to IMDSv1"_ in the `fetchTokenHandler` method is now conditioned on the `LogLevel` being set to `LogDebugWithDeprecated`.
This update prevents the warning from being logged when the `LogLevel` is configured to suppress such messages.

**Testing**
This testing setup demonstrates the modified behavior of the EC2Metadata token provider, using a custom HTTP transport to simulate conditions that trigger a fallback to IMDSv1. The test verifies that the warning message is conditionally logged based on the `LogLevel` setting, ensuring it aligns with the configured log suppression.

```go
package main

import (
	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/credentials"
	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
	"github.com/aws/aws-sdk-go/aws/ec2metadata"
	"github.com/aws/aws-sdk-go/aws/session"
	"net/http"
)

// mock a response that would trigger IMDSv1 fallback
type CustomTransport struct {
	Transport http.RoundTripper
}

func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
	return &http.Response{
		StatusCode: http.StatusForbidden,
		Body:       http.NoBody,
		Header:     make(http.Header),
	}, nil
}

func main() {
	sess, _ := session.NewSession(&aws.Config{
		Region:   aws.String("us-east-1"),
		//LogLevel: aws.LogLevel(aws.LogDebugWithDeprecated), // would raise the warning
		LogLevel: aws.LogLevel(aws.LogOff), // would not raise this warning
		HTTPClient: &http.Client{
			Transport: &CustomTransport{Transport: http.DefaultTransport},
		},
	})
	ec2MetaClient := ec2metadata.New(sess, &aws.Config{})

	creds := credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{
		Client: ec2MetaClient,
	})

	_, _ = creds.Get()
}
```