### PR TITLE
Allow clients to specify the request date on signing requests

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -200,10 +200,10 @@ type Signer struct {
 	// values are the same.
 	DisableRequestBodyOverwrite bool
 
-	// currentTimeFn returns the time value which represents the current time.
+	// CurrentTimeFn returns the time value which represents the current time.
 	// This value should only be used for testing. If it is nil the default
 	// time.Now will be used.
-	currentTimeFn func() time.Time
+	CurrentTimeFn func() time.Time
 
 	// UnsignedPayload will prevent signing of the payload. This will only
 	// work for services that have support for this.
@@ -315,7 +315,7 @@ func (v4 Signer) Presign(r *http.Request, body io.ReadSeeker, service, region st
 }
 
 func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, region string, exp time.Duration, isPresign bool, signTime time.Time) (http.Header, error) {
-	currentTimeFn := v4.currentTimeFn
+	currentTimeFn := v4.CurrentTimeFn
 	if currentTimeFn == nil {
 		currentTimeFn = time.Now
 	}
@@ -465,7 +465,7 @@ func SignSDKRequestWithCurrentTime(req *request.Request, curTimeFn func() time.T
 		v4.Debug = req.Config.LogLevel.Value()
 		v4.Logger = req.Config.Logger
 		v4.DisableHeaderHoisting = req.NotHoist
-		v4.currentTimeFn = curTimeFn
+		v4.CurrentTimeFn = curTimeFn
 		if name == "s3" {
 			// S3 service should not have any escaping applied
 			v4.DisableURIPathEscaping = true


### PR DESCRIPTION
The main intent of this PR is to make the signed urls api flexible with regards to the time when it's created.

GOAL: implement what it's called `Cacheable signed URLs`. Using `v4` presign method, the current `Date` is necessary. Meaning that we can't generate constant `signed urls` according to our needs.

example: we want to avoid certain customers to download again and again the same set of images. And we don't want to make those images publicly available. If those images have a `Control-Cache: private, max-age=3600` policy, it won't be used since each time we sign URLs those will be completely different. Therefore the browser won't be able to re-use them.

original idea: https://advancedweb.hu/cacheable-s3-signed-urls/