### PR TITLE
don't serialize empty lists in ec2query

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/ec2`: Correct empty list serialization behavior.
+  * Empty, non-nil lists should NOT be serialized for this service.

--- a/private/protocol/query/queryutil/queryutil.go
+++ b/private/protocol/query/queryutil/queryutil.go
@@ -122,8 +122,8 @@ func (q *queryParser) parseStruct(v url.Values, value reflect.Value, prefix stri
 }
 
 func (q *queryParser) parseList(v url.Values, value reflect.Value, prefix string, tag reflect.StructTag) error {
-	// If it's empty, generate an empty value
-	if !value.IsNil() && value.Len() == 0 {
+	// If it's empty, and not ec2, generate an empty value
+	if !value.IsNil() && value.Len() == 0 && !q.isEC2 {
 		v.Set(prefix, "")
 		return nil
 	}


### PR DESCRIPTION
Backport https://github.com/aws/aws-sdk-go-v2/issues/2627 to v1. Verified correct behavior w/ `RevokeSecurityGroupEgress` request--

before:
```
Action=RevokeSecurityGroupEgress&GroupId=asdf&IpPermissions=&Version=2016-11-15
```

after:
```
Action=RevokeSecurityGroupEgress&GroupId=asdf&Version=2016-11-15
```