### PR TITLE
save sso cache token expiresAt in UTC

### DIFF
--- a/aws/credentials/ssocreds/sso_cached_token.go
+++ b/aws/credentials/ssocreds/sso_cached_token.go
@@ -229,7 +229,7 @@ func parseRFC3339(v string) (rfc3339, error) {
 
 // MarshalJSON encode rfc3339 to JSON format time
 func (r *rfc3339) MarshalJSON() ([]byte, error) {
-	value := time.Time(*r).Format(time.RFC3339)
+	value := time.Time(*r).UTC().Format(time.RFC3339)
 
 	// Use JSON unmarshal to unescape the quoted value making use of JSON's
 	// quoting rules.


### PR DESCRIPTION
If the expiresAt field is saved with time zone (e.g. `2024-06-10T15:00:06-08:00`) it will fail to load in certain SDKs such as the rust AWS SDK. To avoid this, ensure that it is always saved as a UTC format.

**[IMPORTANT] We [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025) the upcoming end-of-support for AWS SDK for Go v1. We are no longer accepting PRs for additive features to the v1 SDK.**

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
