### PR TITLE
fix sensitive missing on list/map

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* Apply sensitive struct tag to lists/maps with sensitive members.
+  * This change propagates existing sensitive protection to lists/maps.

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -600,7 +600,7 @@ func (ref *ShapeRef) GoTags(toplevel bool, isRequired bool) string {
 		tags = append(tags, ShapeTag{"ignore", "true"})
 	}
 
-	if ref.Shape.Sensitive {
+	if ref.Shape.IsSensitive() {
 		tags = append(tags, ShapeTag{"sensitive", "true"})
 	}
 
@@ -616,6 +616,21 @@ func (s *Shape) HasPayloadMembers() bool {
 		}
 	}
 
+	return false
+}
+
+// IsSensitive checks whether the Shape itself is sensitive, or if the Shape is
+// a collection/map with a sensitive member.
+func (s *Shape) IsSensitive() bool {
+	if s.Sensitive {
+		return true
+	}
+	if s.MemberRef.Shape != nil && s.MemberRef.Shape.Sensitive {
+		return true
+	}
+	if s.ValueRef.Shape != nil && s.ValueRef.Shape.Sensitive {
+		return true
+	}
 	return false
 }
 

--- a/service/appflow/api.go
+++ b/service/appflow/api.go
@@ -5907,7 +5907,7 @@ type CustomAuthCredentials struct {
 	_ struct{} `type:"structure"`
 
 	// A map that holds custom authentication credentials.
-	CredentialsMap map[string]*string `locationName:"credentialsMap" type:"map"`
+	CredentialsMap map[string]*string `locationName:"credentialsMap" type:"map" sensitive:"true"`
 
 	// The custom authentication type that the connector uses.
 	//

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -3296,7 +3296,7 @@ type AgentInfo struct {
 	AgentId *string `locationName:"agentId" min:"10" type:"string"`
 
 	// Network details about the host where the agent or collector resides.
-	AgentNetworkInfoList []*AgentNetworkInfo `locationName:"agentNetworkInfoList" type:"list"`
+	AgentNetworkInfoList []*AgentNetworkInfo `locationName:"agentNetworkInfoList" type:"list" sensitive:"true"`
 
 	// Type of agent.
 	AgentType *string `locationName:"agentType" type:"string"`

--- a/service/apprunner/api.go
+++ b/service/apprunner/api.go
@@ -4576,11 +4576,11 @@ type CodeConfigurationValues struct {
 	//
 	//    * Currently, cross account referencing of Amazon Web Services Systems
 	//    Manager Parameter Store parameter is not supported.
-	RuntimeEnvironmentSecrets map[string]*string `type:"map"`
+	RuntimeEnvironmentSecrets map[string]*string `type:"map" sensitive:"true"`
 
 	// The environment variables that are available to your running App Runner service.
 	// An array of key-value pairs.
-	RuntimeEnvironmentVariables map[string]*string `type:"map"`
+	RuntimeEnvironmentVariables map[string]*string `type:"map" sensitive:"true"`
 
 	// The command App Runner runs to start your application.
 	//
@@ -7395,11 +7395,11 @@ type ImageConfiguration struct {
 	//
 	//    * Currently, cross account referencing of Amazon Web Services Systems
 	//    Manager Parameter Store parameter is not supported.
-	RuntimeEnvironmentSecrets map[string]*string `type:"map"`
+	RuntimeEnvironmentSecrets map[string]*string `type:"map" sensitive:"true"`
 
 	// Environment variables that are available to your running App Runner service.
 	// An array of key-value pairs.
-	RuntimeEnvironmentVariables map[string]*string `type:"map"`
+	RuntimeEnvironmentVariables map[string]*string `type:"map" sensitive:"true"`
 
 	// An optional command that App Runner runs to start the application in the
 	// source image. If specified, this command overrides the Docker image’s default

--- a/service/auditmanager/api.go
+++ b/service/auditmanager/api.go
@@ -7097,7 +7097,7 @@ type AssessmentControlSet struct {
 	Controls []*AssessmentControl `locationName:"controls" type:"list"`
 
 	// The delegations that are associated with the control set.
-	Delegations []*Delegation `locationName:"delegations" type:"list"`
+	Delegations []*Delegation `locationName:"delegations" type:"list" sensitive:"true"`
 
 	// The description for the control set.
 	Description *string `locationName:"description" min:"1" type:"string"`
@@ -7756,7 +7756,7 @@ type AssessmentMetadata struct {
 	CreationTime *time.Time `locationName:"creationTime" type:"timestamp"`
 
 	// The delegations that are associated with the assessment.
-	Delegations []*Delegation `locationName:"delegations" type:"list"`
+	Delegations []*Delegation `locationName:"delegations" type:"list" sensitive:"true"`
 
 	// The description of the assessment.
 	//
@@ -7897,7 +7897,7 @@ type AssessmentMetadataItem struct {
 	CreationTime *time.Time `locationName:"creationTime" type:"timestamp"`
 
 	// The delegations that are associated with the assessment.
-	Delegations []*Delegation `locationName:"delegations" type:"list"`
+	Delegations []*Delegation `locationName:"delegations" type:"list" sensitive:"true"`
 
 	// The unique identifier for the assessment.
 	Id *string `locationName:"id" min:"36" type:"string"`
@@ -8663,7 +8663,7 @@ type BatchCreateDelegationByAssessmentOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The delegations that are associated with the assessment.
-	Delegations []*Delegation `locationName:"delegations" type:"list"`
+	Delegations []*Delegation `locationName:"delegations" type:"list" sensitive:"true"`
 
 	// A list of errors that the BatchCreateDelegationByAssessment API returned.
 	//

--- a/service/bedrock/api.go
+++ b/service/bedrock/api.go
@@ -5246,7 +5246,7 @@ type EvaluationDatasetMetricConfig struct {
 	// name parameter specified in HumanEvaluationCustomMetric.
 	//
 	// MetricNames is a required field
-	MetricNames []*string `locationName:"metricNames" min:"1" type:"list" required:"true"`
+	MetricNames []*string `locationName:"metricNames" min:"1" type:"list" required:"true" sensitive:"true"`
 
 	// The task type you want the model to carry out.
 	//
@@ -6455,7 +6455,7 @@ type GetGuardrailOutput struct {
 
 	// Appears if the status of the guardrail is FAILED. A list of recommendations
 	// to carry out before retrying the request.
-	FailureRecommendations []*string `locationName:"failureRecommendations" type:"list"`
+	FailureRecommendations []*string `locationName:"failureRecommendations" type:"list" sensitive:"true"`
 
 	// The ARN of the guardrail.
 	//
@@ -6489,7 +6489,7 @@ type GetGuardrailOutput struct {
 
 	// Appears if the status is FAILED. A list of reasons for why the guardrail
 	// failed to be created, updated, versioned, or deleted.
-	StatusReasons []*string `locationName:"statusReasons" type:"list"`
+	StatusReasons []*string `locationName:"statusReasons" type:"list" sensitive:"true"`
 
 	// The topic policy that was configured for the guardrail.
 	TopicPolicy *GuardrailTopicPolicy `locationName:"topicPolicy" type:"structure"`
@@ -8394,7 +8394,7 @@ type GuardrailTopic struct {
 
 	// A list of prompts, each of which is an example of a prompt that can be categorized
 	// as belonging to the topic.
-	Examples []*string `locationName:"examples" type:"list"`
+	Examples []*string `locationName:"examples" type:"list" sensitive:"true"`
 
 	// The name of the topic to deny.
 	//
@@ -8466,7 +8466,7 @@ type GuardrailTopicConfig struct {
 
 	// A list of prompts, each of which is an example of a prompt that can be categorized
 	// as belonging to the topic.
-	Examples []*string `locationName:"examples" type:"list"`
+	Examples []*string `locationName:"examples" type:"list" sensitive:"true"`
 
 	// The name of the topic to deny.
 	//

--- a/service/bedrockagent/api.go
+++ b/service/bedrockagent/api.go
@@ -21603,7 +21603,7 @@ type S3DataSourceConfiguration struct {
 
 	// A list of S3 prefixes to include certain files or content. For more information,
 	// see Organizing objects using prefixes (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html).
-	InclusionPrefixes []*string `locationName:"inclusionPrefixes" min:"1" type:"list"`
+	InclusionPrefixes []*string `locationName:"inclusionPrefixes" min:"1" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/bedrockagentruntime/api.go
+++ b/service/bedrockagentruntime/api.go
@@ -2731,7 +2731,7 @@ type FilePart struct {
 	_ struct{} `type:"structure"`
 
 	// Files containing intermediate response for the user.
-	Files []*OutputFile `locationName:"files" type:"list"`
+	Files []*OutputFile `locationName:"files" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -4423,10 +4423,10 @@ type GuardrailTrace struct {
 	Action *string `locationName:"action" type:"string" enum:"GuardrailAction"`
 
 	// The details of the input assessments used in the Guardrail Trace.
-	InputAssessments []*GuardrailAssessment `locationName:"inputAssessments" type:"list"`
+	InputAssessments []*GuardrailAssessment `locationName:"inputAssessments" type:"list" sensitive:"true"`
 
 	// The details of the output assessments used in the Guardrail Trace.
-	OutputAssessments []*GuardrailAssessment `locationName:"outputAssessments" type:"list"`
+	OutputAssessments []*GuardrailAssessment `locationName:"outputAssessments" type:"list" sensitive:"true"`
 
 	// The details of the trace Id used in the Guardrail Trace.
 	TraceId *string `locationName:"traceId" min:"2" type:"string"`
@@ -7357,11 +7357,11 @@ type RetrievalFilter struct {
 
 	// Knowledge base data sources are returned if their metadata attributes fulfill
 	// all the filter conditions inside this list.
-	AndAll []*RetrievalFilter `locationName:"andAll" min:"2" type:"list"`
+	AndAll []*RetrievalFilter `locationName:"andAll" min:"2" type:"list" sensitive:"true"`
 
 	// Knowledge base data sources are returned if their metadata attributes fulfill
 	// at least one of the filter conditions inside this list.
-	OrAll []*RetrievalFilter `locationName:"orAll" min:"2" type:"list"`
+	OrAll []*RetrievalFilter `locationName:"orAll" min:"2" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/billingconductor/api.go
+++ b/service/billingconductor/api.go
@@ -7986,7 +7986,7 @@ type ListCustomLineItemsFilter struct {
 	BillingGroups []*string `min:"1" type:"list"`
 
 	// A list of custom line items to retrieve information.
-	Names []*string `min:"1" type:"list"`
+	Names []*string `min:"1" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/chime/api.go
+++ b/service/chime/api.go
@@ -24028,7 +24028,7 @@ type AssociatePhoneNumbersWithVoiceConnectorGroupInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// If true, associates the provided phone numbers with the provided Amazon Chime
 	// Voice Connector Group and removes any previously existing associations. If
@@ -24136,7 +24136,7 @@ type AssociatePhoneNumbersWithVoiceConnectorInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// If true, associates the provided phone numbers with the provided Amazon Chime
 	// Voice Connector and removes any previously existing associations. If false,
@@ -28880,7 +28880,7 @@ type CreatePhoneNumberOrderInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The phone number product type.
 	//
@@ -28997,7 +28997,7 @@ type CreateProxySessionInput struct {
 	// The participant phone numbers.
 	//
 	// ParticipantPhoneNumbers is a required field
-	ParticipantPhoneNumbers []*string `min:"2" type:"list" required:"true"`
+	ParticipantPhoneNumbers []*string `min:"2" type:"list" required:"true" sensitive:"true"`
 
 	// The Amazon Chime voice connector ID.
 	//
@@ -29383,7 +29383,7 @@ type CreateSipMediaApplicationCallInput struct {
 	FromPhoneNumber *string `type:"string" required:"true" sensitive:"true"`
 
 	// The SIP headers added to an outbound call leg.
-	SipHeaders map[string]*string `type:"map"`
+	SipHeaders map[string]*string `type:"map" sensitive:"true"`
 
 	// The ID of the SIP media application.
 	//
@@ -32307,7 +32307,7 @@ type DeleteVoiceConnectorTerminationCredentialsInput struct {
 	// format.
 	//
 	// Usernames is a required field
-	Usernames []*string `type:"list" required:"true"`
+	Usernames []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The Amazon Chime Voice Connector ID.
 	//
@@ -33447,7 +33447,7 @@ type DisassociatePhoneNumbersFromVoiceConnectorGroupInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The Amazon Chime Voice Connector group ID.
 	//
@@ -33543,7 +33543,7 @@ type DisassociatePhoneNumbersFromVoiceConnectorInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The Amazon Chime Voice Connector ID.
 	//
@@ -37157,7 +37157,7 @@ type InviteUsersInput struct {
 	// The user email addresses to which to send the email invitation.
 	//
 	// UserEmailList is a required field
-	UserEmailList []*string `type:"list" required:"true"`
+	UserEmailList []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The user type.
 	UserType *string `type:"string" enum:"UserType"`
@@ -40526,7 +40526,7 @@ type ListVoiceConnectorTerminationCredentialsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A list of user names.
-	Usernames []*string `type:"list"`
+	Usernames []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -44595,7 +44595,7 @@ type SearchAvailablePhoneNumbersOutput struct {
 	_ struct{} `type:"structure"`
 
 	// List of phone numbers, in E.164 format.
-	E164PhoneNumbers []*string `type:"list"`
+	E164PhoneNumbers []*string `type:"list" sensitive:"true"`
 
 	// The token used to retrieve the next page of search results.
 	NextToken *string `type:"string"`
@@ -44640,7 +44640,7 @@ type SelectedVideoStreams struct {
 	AttendeeIds []*string `min:"1" type:"list"`
 
 	// The external user IDs of the streams selected for a media capture pipeline.
-	ExternalUserIds []*string `min:"1" type:"list"`
+	ExternalUserIds []*string `min:"1" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -46591,7 +46591,7 @@ type UntagAttendeeInput struct {
 	// The tag keys.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `min:"1" type:"list" required:"true"`
+	TagKeys []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -46691,7 +46691,7 @@ type UntagMeetingInput struct {
 	// The tag keys.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `min:"1" type:"list" required:"true"`
+	TagKeys []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -46783,7 +46783,7 @@ type UntagResourceInput struct {
 	// The tag keys.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `min:"1" type:"list" required:"true"`
+	TagKeys []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -48425,7 +48425,7 @@ type UpdateSipMediaApplicationCallInput struct {
 	// event. Can contain 0-20 key-value pairs.
 	//
 	// Arguments is a required field
-	Arguments map[string]*string `type:"map" required:"true"`
+	Arguments map[string]*string `type:"map" required:"true" sensitive:"true"`
 
 	// The ID of the SIP media application handling the call.
 	//

--- a/service/chimesdkidentity/api.go
+++ b/service/chimesdkidentity/api.go
@@ -7904,7 +7904,7 @@ type UntagResourceInput struct {
 	// The tag keys.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `min:"1" type:"list" required:"true"`
+	TagKeys []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/chimesdkmediapipelines/api.go
+++ b/service/chimesdkmediapipelines/api.go
@@ -10787,7 +10787,7 @@ type SelectedVideoStreams struct {
 	AttendeeIds []*string `min:"1" type:"list"`
 
 	// The external user IDs of the streams selected for a media pipeline.
-	ExternalUserIds []*string `min:"1" type:"list"`
+	ExternalUserIds []*string `min:"1" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/chimesdkmessaging/api.go
+++ b/service/chimesdkmessaging/api.go
@@ -12688,7 +12688,7 @@ type MessageAttributeValue struct {
 	_ struct{} `type:"structure"`
 
 	// The strings in a message attribute value.
-	StringValues []*string `type:"list"`
+	StringValues []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -14819,7 +14819,7 @@ type UntagResourceInput struct {
 	// The tag keys.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `min:"1" type:"list" required:"true"`
+	TagKeys []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/chimesdkvoice/api.go
+++ b/service/chimesdkvoice/api.go
@@ -10159,7 +10159,7 @@ type AssociatePhoneNumbersWithVoiceConnectorGroupInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// If true, associates the provided phone numbers with the provided Amazon Chime
 	// SDK Voice Connector Group and removes any previously existing associations.
@@ -10267,7 +10267,7 @@ type AssociatePhoneNumbersWithVoiceConnectorInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// If true, associates the provided phone numbers with the provided Amazon Chime
 	// SDK Voice Connector and removes any previously existing associations. If
@@ -10836,7 +10836,7 @@ type CreatePhoneNumberOrderInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// Specifies the name assigned to one or more phone numbers.
 	//
@@ -10966,7 +10966,7 @@ type CreateProxySessionInput struct {
 	// The participant phone numbers.
 	//
 	// ParticipantPhoneNumbers is a required field
-	ParticipantPhoneNumbers []*string `min:"2" type:"list" required:"true"`
+	ParticipantPhoneNumbers []*string `min:"2" type:"list" required:"true" sensitive:"true"`
 
 	// The Voice Connector ID.
 	//
@@ -11109,7 +11109,7 @@ type CreateSipMediaApplicationCallInput struct {
 
 	// Context passed to a CreateSipMediaApplication API call. For example, you
 	// could pass key-value pairs such as: "FirstName": "John", "LastName": "Doe"
-	ArgumentsMap map[string]*string `type:"map"`
+	ArgumentsMap map[string]*string `type:"map" sensitive:"true"`
 
 	// The phone number that a user calls from. This is a phone number in your Amazon
 	// Chime SDK phone number inventory.
@@ -11122,7 +11122,7 @@ type CreateSipMediaApplicationCallInput struct {
 	FromPhoneNumber *string `type:"string" required:"true" sensitive:"true"`
 
 	// The SIP headers added to an outbound call leg.
-	SipHeaders map[string]*string `type:"map"`
+	SipHeaders map[string]*string `type:"map" sensitive:"true"`
 
 	// The ID of the SIP media application.
 	//
@@ -12836,7 +12836,7 @@ type DeleteVoiceConnectorTerminationCredentialsInput struct {
 	// format.
 	//
 	// Usernames is a required field
-	Usernames []*string `type:"list" required:"true"`
+	Usernames []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The Voice Connector ID.
 	//
@@ -13134,7 +13134,7 @@ type DisassociatePhoneNumbersFromVoiceConnectorGroupInput struct {
 	// The list of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The Voice Connector group ID.
 	//
@@ -13230,7 +13230,7 @@ type DisassociatePhoneNumbersFromVoiceConnectorInput struct {
 	// List of phone numbers, in E.164 format.
 	//
 	// E164PhoneNumbers is a required field
-	E164PhoneNumbers []*string `type:"list" required:"true"`
+	E164PhoneNumbers []*string `type:"list" required:"true" sensitive:"true"`
 
 	// The Voice Connector ID.
 	//
@@ -16249,7 +16249,7 @@ type ListVoiceConnectorTerminationCredentialsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A list of user names.
-	Usernames []*string `type:"list"`
+	Usernames []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -18839,7 +18839,7 @@ type SearchAvailablePhoneNumbersOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Confines a search to just the phone numbers in the E.164 format.
-	E164PhoneNumbers []*string `type:"list"`
+	E164PhoneNumbers []*string `type:"list" sensitive:"true"`
 
 	// The token used to return the next page of results.
 	NextToken *string `type:"string"`
@@ -19160,7 +19160,7 @@ type SipMediaApplicationAlexaSkillConfiguration struct {
 	// The ID of the Alexa Skill configuration.
 	//
 	// AlexaSkillIds is a required field
-	AlexaSkillIds []*string `min:"1" type:"list" required:"true"`
+	AlexaSkillIds []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 
 	// The status of the Alexa Skill configuration.
 	//
@@ -20725,7 +20725,7 @@ type UntagResourceInput struct {
 	// The keys of the tags being removed from the resource.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `min:"1" type:"list" required:"true"`
+	TagKeys []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -21263,7 +21263,7 @@ type UpdateSipMediaApplicationCallInput struct {
 	// event. Can contain 0-20 key-value pairs.
 	//
 	// Arguments is a required field
-	Arguments map[string]*string `type:"map" required:"true"`
+	Arguments map[string]*string `type:"map" required:"true" sensitive:"true"`
 
 	// The ID of the SIP media application handling the call.
 	//

--- a/service/cleanrooms/api.go
+++ b/service/cleanrooms/api.go
@@ -7493,7 +7493,7 @@ type AnalysisTemplate struct {
 	_ struct{} `type:"structure"`
 
 	// The parameters of the analysis template.
-	AnalysisParameters []*AnalysisParameter `locationName:"analysisParameters" type:"list"`
+	AnalysisParameters []*AnalysisParameter `locationName:"analysisParameters" type:"list" sensitive:"true"`
 
 	// The Amazon Resource Name (ARN) of the analysis template.
 	//
@@ -8598,7 +8598,7 @@ type CollaborationAnalysisTemplate struct {
 	_ struct{} `type:"structure"`
 
 	// The analysis parameters that have been specified in the analysis template.
-	AnalysisParameters []*AnalysisParameter `locationName:"analysisParameters" type:"list"`
+	AnalysisParameters []*AnalysisParameter `locationName:"analysisParameters" type:"list" sensitive:"true"`
 
 	// The Amazon Resource Name (ARN) of the analysis template.
 	//
@@ -10823,7 +10823,7 @@ type CreateAnalysisTemplateInput struct {
 	_ struct{} `type:"structure"`
 
 	// The parameters of the analysis template.
-	AnalysisParameters []*AnalysisParameter `locationName:"analysisParameters" type:"list"`
+	AnalysisParameters []*AnalysisParameter `locationName:"analysisParameters" type:"list" sensitive:"true"`
 
 	// The description of the analysis template.
 	Description *string `locationName:"description" type:"string"`

--- a/service/codestar/api.go
+++ b/service/codestar/api.go
@@ -4670,7 +4670,7 @@ type Toolchain struct {
 
 	// The list of parameter overrides to be passed into the toolchain template
 	// during stack provisioning, if any.
-	StackParameters map[string]*string `locationName:"stackParameters" type:"map"`
+	StackParameters map[string]*string `locationName:"stackParameters" type:"map" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/connect/api.go
+++ b/service/connect/api.go
@@ -69690,7 +69690,7 @@ type SearchableContactAttributesCriteria struct {
 	// The list of values to search for within a user-defined contact attribute.
 	//
 	// Values is a required field
-	Values []*string `type:"list" required:"true"`
+	Values []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -74760,7 +74760,7 @@ type TranscriptCriteria struct {
 	// The words or phrases used to search within a transcript.
 	//
 	// SearchText is a required field
-	SearchText []*string `type:"list" required:"true"`
+	SearchText []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -82658,7 +82658,7 @@ type ViewContent struct {
 	_ struct{} `type:"structure"`
 
 	// A list of possible actions from the view.
-	Actions []*string `type:"list"`
+	Actions []*string `type:"list" sensitive:"true"`
 
 	// The data schema matching data that the view template must be provided to
 	// render.
@@ -82715,7 +82715,7 @@ type ViewInputContent struct {
 	_ struct{} `type:"structure"`
 
 	// A list of possible actions from the view.
-	Actions []*string `type:"list"`
+	Actions []*string `type:"list" sensitive:"true"`
 
 	// The view template representing the structure of the view.
 	Template *string `type:"string"`

--- a/service/connectparticipant/api.go
+++ b/service/connectparticipant/api.go
@@ -3104,7 +3104,7 @@ type ViewContent struct {
 	_ struct{} `type:"structure"`
 
 	// A list of actions possible from the view
-	Actions []*string `type:"list"`
+	Actions []*string `type:"list" sensitive:"true"`
 
 	// The schema representing the input data that the view template must be supplied
 	// to render.

--- a/service/connectwisdomservice/api.go
+++ b/service/connectwisdomservice/api.go
@@ -6143,7 +6143,7 @@ type CreateQuickResponseInput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Connect channels this quick response applies to.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// A unique, case-sensitive identifier that you provide to ensure the idempotency
 	// of the request. If not provided, the Amazon Web Services SDK populates this
@@ -8161,7 +8161,7 @@ type GroupingConfiguration struct {
 	//    * When setting criteria to RoutingProfileArn, you need to provide a list
 	//    of ARNs of Amazon Connect routing profiles (https://docs.aws.amazon.com/connect/latest/APIReference/API_RoutingProfile.html)
 	//    as values of this parameter.
-	Values []*string `locationName:"values" type:"list"`
+	Values []*string `locationName:"values" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -10099,7 +10099,7 @@ type QuickResponseData struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The media type of the quick response content.
 	//
@@ -10772,7 +10772,7 @@ type QuickResponseSearchResultData struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The media type of the quick response content.
 	//
@@ -11003,7 +11003,7 @@ type QuickResponseSummary struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The media type of the quick response content.
 	//
@@ -13333,7 +13333,7 @@ type UpdateQuickResponseInput struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The updated content of the quick response.
 	Content *QuickResponseDataProvider `locationName:"content" type:"structure"`

--- a/service/deadline/api.go
+++ b/service/deadline/api.go
@@ -12939,7 +12939,7 @@ type Attachments struct {
 	// A list of manifests which describe job attachment configurations.
 	//
 	// Manifests is a required field
-	Manifests []*ManifestProperties `locationName:"manifests" min:"1" type:"list" required:"true"`
+	Manifests []*ManifestProperties `locationName:"manifests" min:"1" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -15154,7 +15154,7 @@ type CreateQueueInput struct {
 	JobRunAsUser *JobRunAsUser `locationName:"jobRunAsUser" type:"structure"`
 
 	// The file system location name to include in the queue.
-	RequiredFileSystemLocationNames []*string `locationName:"requiredFileSystemLocationNames" type:"list"`
+	RequiredFileSystemLocationNames []*string `locationName:"requiredFileSystemLocationNames" type:"list" sensitive:"true"`
 
 	// The IAM role ARN that workers will use while running jobs for this queue.
 	RoleArn *string `locationName:"roleArn" type:"string"`
@@ -15333,7 +15333,7 @@ type CreateStorageProfileInput struct {
 	FarmId *string `location:"uri" locationName:"farmId" type:"string" required:"true"`
 
 	// File system paths to include in the storage profile.
-	FileSystemLocations []*FileSystemLocation `locationName:"fileSystemLocations" type:"list"`
+	FileSystemLocations []*FileSystemLocation `locationName:"fileSystemLocations" type:"list" sensitive:"true"`
 
 	// The type of operating system (OS) for the storage profile.
 	//
@@ -20456,7 +20456,7 @@ type GetQueueOutput struct {
 	QueueId *string `locationName:"queueId" type:"string" required:"true"`
 
 	// A list of the required file system location names in the queue.
-	RequiredFileSystemLocationNames []*string `locationName:"requiredFileSystemLocationNames" type:"list"`
+	RequiredFileSystemLocationNames []*string `locationName:"requiredFileSystemLocationNames" type:"list" sensitive:"true"`
 
 	// The IAM role ARN.
 	RoleArn *string `locationName:"roleArn" type:"string"`
@@ -21598,7 +21598,7 @@ type GetStorageProfileForQueueOutput struct {
 	DisplayName *string `locationName:"displayName" min:"1" type:"string" required:"true"`
 
 	// The location of the files for the storage profile within the queue.
-	FileSystemLocations []*FileSystemLocation `locationName:"fileSystemLocations" type:"list"`
+	FileSystemLocations []*FileSystemLocation `locationName:"fileSystemLocations" type:"list" sensitive:"true"`
 
 	// The operating system of the storage profile in the queue.
 	//
@@ -21738,7 +21738,7 @@ type GetStorageProfileOutput struct {
 	DisplayName *string `locationName:"displayName" min:"1" type:"string" required:"true"`
 
 	// The location of the files for the storage profile.
-	FileSystemLocations []*FileSystemLocation `locationName:"fileSystemLocations" type:"list"`
+	FileSystemLocations []*FileSystemLocation `locationName:"fileSystemLocations" type:"list" sensitive:"true"`
 
 	// The operating system (OS) for the storage profile.
 	//
@@ -22741,7 +22741,7 @@ type JobDetailsEntity struct {
 	Parameters map[string]*JobParameter `locationName:"parameters" type:"map" sensitive:"true"`
 
 	// The path mapping rules.
-	PathMappingRules []*PathMappingRule `locationName:"pathMappingRules" type:"list"`
+	PathMappingRules []*PathMappingRule `locationName:"pathMappingRules" type:"list" sensitive:"true"`
 
 	// The queue role ARN.
 	QueueRoleArn *string `locationName:"queueRoleArn" type:"string"`
@@ -33575,10 +33575,10 @@ type UpdateQueueInput struct {
 	QueueId *string `location:"uri" locationName:"queueId" type:"string" required:"true"`
 
 	// The required file system location names to add to the queue.
-	RequiredFileSystemLocationNamesToAdd []*string `locationName:"requiredFileSystemLocationNamesToAdd" type:"list"`
+	RequiredFileSystemLocationNamesToAdd []*string `locationName:"requiredFileSystemLocationNamesToAdd" type:"list" sensitive:"true"`
 
 	// The required file system location names to remove from the queue.
-	RequiredFileSystemLocationNamesToRemove []*string `locationName:"requiredFileSystemLocationNamesToRemove" type:"list"`
+	RequiredFileSystemLocationNamesToRemove []*string `locationName:"requiredFileSystemLocationNamesToRemove" type:"list" sensitive:"true"`
 
 	// The IAM role ARN that's used to run jobs from this queue.
 	RoleArn *string `locationName:"roleArn" type:"string"`
@@ -34051,10 +34051,10 @@ type UpdateStorageProfileInput struct {
 	FarmId *string `location:"uri" locationName:"farmId" type:"string" required:"true"`
 
 	// The file system location names to add.
-	FileSystemLocationsToAdd []*FileSystemLocation `locationName:"fileSystemLocationsToAdd" type:"list"`
+	FileSystemLocationsToAdd []*FileSystemLocation `locationName:"fileSystemLocationsToAdd" type:"list" sensitive:"true"`
 
 	// The file system location names to remove.
-	FileSystemLocationsToRemove []*FileSystemLocation `locationName:"fileSystemLocationsToRemove" type:"list"`
+	FileSystemLocationsToRemove []*FileSystemLocation `locationName:"fileSystemLocationsToRemove" type:"list" sensitive:"true"`
 
 	// The OS system to update.
 	OsFamily *string `locationName:"osFamily" type:"string" enum:"StorageProfileOperatingSystemFamily"`

--- a/service/ebs/api.go
+++ b/service/ebs/api.go
@@ -1504,7 +1504,7 @@ type ListChangedBlocksOutput struct {
 	BlockSize *int64 `type:"integer"`
 
 	// An array of objects containing information about the changed blocks.
-	ChangedBlocks []*ChangedBlock `type:"list"`
+	ChangedBlocks []*ChangedBlock `type:"list" sensitive:"true"`
 
 	// The time when the BlockToken expires.
 	ExpiryTime *time.Time `type:"timestamp"`

--- a/service/emrcontainers/api.go
+++ b/service/emrcontainers/api.go
@@ -7140,7 +7140,7 @@ type SparkSubmitJobDriver struct {
 	EntryPoint *string `locationName:"entryPoint" min:"1" type:"string" required:"true" sensitive:"true"`
 
 	// The arguments for job application.
-	EntryPointArguments []*string `locationName:"entryPointArguments" type:"list"`
+	EntryPointArguments []*string `locationName:"entryPointArguments" type:"list" sensitive:"true"`
 
 	// The Spark submit parameters that are used for job runs.
 	//

--- a/service/emrserverless/api.go
+++ b/service/emrserverless/api.go
@@ -5322,7 +5322,7 @@ type SparkSubmit struct {
 	EntryPoint *string `locationName:"entryPoint" min:"1" type:"string" required:"true" sensitive:"true"`
 
 	// The arguments for the Spark submit job run.
-	EntryPointArguments []*string `locationName:"entryPointArguments" type:"list"`
+	EntryPointArguments []*string `locationName:"entryPointArguments" type:"list" sensitive:"true"`
 
 	// The parameters for the Spark submit job run.
 	//

--- a/service/forecastservice/api.go
+++ b/service/forecastservice/api.go
@@ -21104,7 +21104,7 @@ type UntagResourceInput struct {
 	// The keys of the tags to be removed.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `type:"list" required:"true"`
+	TagKeys []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/frauddetector/api.go
+++ b/service/frauddetector/api.go
@@ -9761,7 +9761,7 @@ type CreateListInput struct {
 	// The names of the elements, if providing. You can also create an empty list
 	// and add elements later using the UpdateList (https://docs.aws.amazon.com/frauddetector/latest/api/API_Updatelist.html)
 	// API.
-	Elements []*string `locationName:"elements" type:"list"`
+	Elements []*string `locationName:"elements" type:"list" sensitive:"true"`
 
 	// The name of the list.
 	//
@@ -12583,7 +12583,7 @@ type Event struct {
 	CurrentLabel *string `locationName:"currentLabel" type:"string"`
 
 	// The event entities.
-	Entities []*Entity `locationName:"entities" type:"list"`
+	Entities []*Entity `locationName:"entities" type:"list" sensitive:"true"`
 
 	// The event ID.
 	EventId *string `locationName:"eventId" type:"string"`
@@ -12598,7 +12598,7 @@ type Event struct {
 	// Names of the event type's variables you defined in Amazon Fraud Detector
 	// to represent data elements and their corresponding values for the event you
 	// are sending for evaluation.
-	EventVariables map[string]*string `locationName:"eventVariables" type:"map"`
+	EventVariables map[string]*string `locationName:"eventVariables" type:"map" sensitive:"true"`
 
 	// The timestamp associated with the label to update. The timestamp must be
 	// specified using ISO 8601 standard in UTC.
@@ -14206,7 +14206,7 @@ type GetEventPredictionInput struct {
 	// use "UNKNOWN."
 	//
 	// Entities is a required field
-	Entities []*Entity `locationName:"entities" type:"list" required:"true"`
+	Entities []*Entity `locationName:"entities" type:"list" required:"true" sensitive:"true"`
 
 	// The unique ID used to identify the event.
 	//
@@ -14248,7 +14248,7 @@ type GetEventPredictionInput struct {
 	// that is provided for the variable.
 	//
 	// EventVariables is a required field
-	EventVariables map[string]*string `locationName:"eventVariables" min:"1" type:"map" required:"true"`
+	EventVariables map[string]*string `locationName:"eventVariables" min:"1" type:"map" required:"true" sensitive:"true"`
 
 	// The Amazon SageMaker model endpoint input data blobs.
 	//
@@ -14784,7 +14784,7 @@ type GetEventTypesOutput struct {
 	_ struct{} `type:"structure"`
 
 	// An array of event types.
-	EventTypes []*EventType `locationName:"eventTypes" type:"list"`
+	EventTypes []*EventType `locationName:"eventTypes" type:"list" sensitive:"true"`
 
 	// The next page token.
 	NextToken *string `locationName:"nextToken" type:"string"`
@@ -15154,7 +15154,7 @@ type GetListElementsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The list elements.
-	Elements []*string `locationName:"elements" type:"list"`
+	Elements []*string `locationName:"elements" type:"list" sensitive:"true"`
 
 	// The next page token.
 	NextToken *string `locationName:"nextToken" type:"string"`
@@ -18951,7 +18951,7 @@ type SendEventInput struct {
 	// An array of entities.
 	//
 	// Entities is a required field
-	Entities []*Entity `locationName:"entities" type:"list" required:"true"`
+	Entities []*Entity `locationName:"entities" type:"list" required:"true" sensitive:"true"`
 
 	// The event ID to upload.
 	//
@@ -18974,7 +18974,7 @@ type SendEventInput struct {
 	// are sending for evaluation.
 	//
 	// EventVariables is a required field
-	EventVariables map[string]*string `locationName:"eventVariables" min:"1" type:"map" required:"true"`
+	EventVariables map[string]*string `locationName:"eventVariables" min:"1" type:"map" required:"true" sensitive:"true"`
 
 	// The timestamp associated with the label. Required if specifying assignedLabel.
 	LabelTimestamp *string `locationName:"labelTimestamp" min:"10" type:"string"`
@@ -20404,7 +20404,7 @@ type UpdateListInput struct {
 	//
 	// If you are deleting all elements from the list, use REPLACE for the updateMode
 	// and provide an empty list (0 elements).
-	Elements []*string `locationName:"elements" type:"list"`
+	Elements []*string `locationName:"elements" type:"list" sensitive:"true"`
 
 	// The name of the list to update.
 	//

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -651,7 +651,7 @@ type ActiveContext struct {
 	// values for slots in subsequent events.
 	//
 	// Parameters is a required field
-	Parameters map[string]*string `locationName:"parameters" type:"map" required:"true"`
+	Parameters map[string]*string `locationName:"parameters" type:"map" required:"true" sensitive:"true"`
 
 	// The length of time or number of turns that a context remains active.
 	//

--- a/service/lexruntimev2/api.go
+++ b/service/lexruntimev2/api.go
@@ -1093,7 +1093,7 @@ type ActiveContext struct {
 	// for the session are cleared.
 	//
 	// ContextAttributes is a required field
-	ContextAttributes map[string]*string `locationName:"contextAttributes" type:"map" required:"true"`
+	ContextAttributes map[string]*string `locationName:"contextAttributes" type:"map" required:"true" sensitive:"true"`
 
 	// The name of the context.
 	//

--- a/service/locationservice/api.go
+++ b/service/locationservice/api.go
@@ -8261,7 +8261,7 @@ type CalculateRouteInput struct {
 	// is longer than 400 km returns a 400 RoutesValidationException error.
 	//
 	// Valid Values: [-180 to 180,-90 to 90]
-	WaypointPositions [][]*float64 `type:"list"`
+	WaypointPositions [][]*float64 `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -8436,7 +8436,7 @@ type CalculateRouteMatrixInput struct {
 	// Valid Values: [-180 to 180,-90 to 90]
 	//
 	// DeparturePositions is a required field
-	DeparturePositions [][]*float64 `min:"1" type:"list" required:"true"`
+	DeparturePositions [][]*float64 `min:"1" type:"list" required:"true" sensitive:"true"`
 
 	// Specifies the desired time of departure. Uses the given time to calculate
 	// the route matrix. You can't set both DepartureTime and DepartNow. If neither
@@ -8466,7 +8466,7 @@ type CalculateRouteMatrixInput struct {
 	// Valid Values: [-180 to 180,-90 to 90]
 	//
 	// DestinationPositions is a required field
-	DestinationPositions [][]*float64 `min:"1" type:"list" required:"true"`
+	DestinationPositions [][]*float64 `min:"1" type:"list" required:"true" sensitive:"true"`
 
 	// Set the unit system to specify the distance.
 	//
@@ -8631,11 +8631,11 @@ type CalculateRouteMatrixOutput struct {
 	// positions are snapped to the closest road. For Esri route calculator resources,
 	// this returns the list of departure/origin positions used for calculation
 	// of the RouteMatrix.
-	SnappedDeparturePositions [][]*float64 `min:"1" type:"list"`
+	SnappedDeparturePositions [][]*float64 `min:"1" type:"list" sensitive:"true"`
 
 	// The list of destination positions for the route matrix used for calculation
 	// of the RouteMatrix.
-	SnappedDestinationPositions [][]*float64 `min:"1" type:"list"`
+	SnappedDestinationPositions [][]*float64 `min:"1" type:"list" sensitive:"true"`
 
 	// Contains information about the route matrix, DataSource, DistanceUnit, RouteCount
 	// and ErrorCount.
@@ -14517,7 +14517,7 @@ type LegGeometry struct {
 	// last position is the closest to the end position for the leg.
 	//
 	//    * For example, [[-123.117, 49.284],[-123.115, 49.285],[-123.115, 49.285]]
-	LineString [][]*float64 `min:"2" type:"list"`
+	LineString [][]*float64 `min:"2" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/mailmanager/api.go
+++ b/service/mailmanager/api.go
@@ -10914,7 +10914,7 @@ type ReplaceRecipientAction struct {
 	_ struct{} `type:"structure"`
 
 	// This action specifies the replacement recipient email addresses to insert.
-	ReplaceWith []*string `min:"1" type:"list"`
+	ReplaceWith []*string `min:"1" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -13347,7 +13347,7 @@ type UntagResourceInput struct {
 	// the specified resource.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `type:"list" required:"true"`
+	TagKeys []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/panorama/api.go
+++ b/service/panorama/api.go
@@ -4200,7 +4200,7 @@ type CreateNodeFromTemplateJobInput struct {
 	// Template parameters for the node.
 	//
 	// TemplateParameters is a required field
-	TemplateParameters map[string]*string `type:"map" required:"true"`
+	TemplateParameters map[string]*string `type:"map" required:"true" sensitive:"true"`
 
 	// The type of node.
 	//
@@ -5751,7 +5751,7 @@ type DescribeNodeFromTemplateJobOutput struct {
 	// The job's template parameters.
 	//
 	// TemplateParameters is a required field
-	TemplateParameters map[string]*string `type:"map" required:"true"`
+	TemplateParameters map[string]*string `type:"map" required:"true" sensitive:"true"`
 
 	// The job's template type.
 	//

--- a/service/paymentcryptography/api.go
+++ b/service/paymentcryptography/api.go
@@ -5516,7 +5516,7 @@ type KeyBlockHeaders struct {
 	// 2 characters are reserved for optional block ID and 2 characters reserved
 	// for optional block length. More than one optional blocks can be included
 	// as long as the combined length does not increase 112 characters.
-	OptionalBlocks map[string]*string `type:"map"`
+	OptionalBlocks map[string]*string `type:"map" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/personalizeevents/api.go
+++ b/service/personalizeevents/api.go
@@ -554,7 +554,7 @@ type ActionInteraction struct {
 	// the user. For example, ["actionId1", "actionId2", "actionId3"]. Amazon Personalize
 	// doesn't use impressions data from action interaction events. Instead, record
 	// multiple events for each action and use the Viewed event type.
-	Impression []*string `locationName:"impression" min:"1" type:"list"`
+	Impression []*string `locationName:"impression" min:"1" type:"list" sensitive:"true"`
 
 	// A string map of event-specific data that you might choose to record. For
 	// example, if a user takes an action, other than the action ID, you might also
@@ -756,7 +756,7 @@ type Event struct {
 	// user. For example, ["itemId1", "itemId2", "itemId3"]. Provide a list of items
 	// to manually record impressions data for an event. For more information on
 	// recording impressions data, see Recording impressions data (https://docs.aws.amazon.com/personalize/latest/dg/recording-events.html#putevents-including-impressions-data).
-	Impression []*string `locationName:"impression" min:"1" type:"list"`
+	Impression []*string `locationName:"impression" min:"1" type:"list" sensitive:"true"`
 
 	// The item ID key that corresponds to the ITEM_ID field of the Item interactions
 	// dataset's schema.
@@ -1308,7 +1308,7 @@ type PutEventsInput struct {
 	// A list of event data from the session.
 	//
 	// EventList is a required field
-	EventList []*Event `locationName:"eventList" min:"1" type:"list" required:"true"`
+	EventList []*Event `locationName:"eventList" min:"1" type:"list" required:"true" sensitive:"true"`
 
 	// The session ID associated with the user's visit. Your application generates
 	// the sessionId when a user first visits your website or uses your application.

--- a/service/personalizeruntime/api.go
+++ b/service/personalizeruntime/api.go
@@ -308,7 +308,7 @@ type GetActionRecommendationsInput struct {
 	// use that portion of the expression to filter recommendations.
 	//
 	// For more information, see Filtering recommendations and user segments (https://docs.aws.amazon.com/personalize/latest/dg/filter.html).
-	FilterValues map[string]*string `locationName:"filterValues" type:"map"`
+	FilterValues map[string]*string `locationName:"filterValues" type:"map" sensitive:"true"`
 
 	// The number of results to return. The default is 5. The maximum is 100.
 	NumResults *int64 `locationName:"numResults" type:"integer"`
@@ -419,7 +419,7 @@ type GetPersonalizedRankingInput struct {
 	// The contextual metadata to use when getting recommendations. Contextual metadata
 	// includes any interaction information that might be relevant when getting
 	// a user's recommendations, such as the user's current location or device type.
-	Context map[string]*string `locationName:"context" type:"map"`
+	Context map[string]*string `locationName:"context" type:"map" sensitive:"true"`
 
 	// The Amazon Resource Name (ARN) of a filter you created to include items or
 	// exclude items from recommendations for a given user. For more information,
@@ -438,7 +438,7 @@ type GetPersonalizedRankingInput struct {
 	// that portion of the expression to filter recommendations.
 	//
 	// For more information, see Filtering Recommendations (https://docs.aws.amazon.com/personalize/latest/dg/filter.html).
-	FilterValues map[string]*string `locationName:"filterValues" type:"map"`
+	FilterValues map[string]*string `locationName:"filterValues" type:"map" sensitive:"true"`
 
 	// A list of items (by itemId) to rank. If an item was not included in the training
 	// dataset, the item is appended to the end of the reranked list. If you are
@@ -593,7 +593,7 @@ type GetRecommendationsInput struct {
 	// The contextual metadata to use when getting recommendations. Contextual metadata
 	// includes any interaction information that might be relevant when getting
 	// a user's recommendations, such as the user's current location or device type.
-	Context map[string]*string `locationName:"context" type:"map"`
+	Context map[string]*string `locationName:"context" type:"map" sensitive:"true"`
 
 	// The ARN of the filter to apply to the returned recommendations. For more
 	// information, see Filtering Recommendations (https://docs.aws.amazon.com/personalize/latest/dg/filter.html).
@@ -613,7 +613,7 @@ type GetRecommendationsInput struct {
 	// that portion of the expression to filter recommendations.
 	//
 	// For more information, see Filtering recommendations and user segments (https://docs.aws.amazon.com/personalize/latest/dg/filter.html).
-	FilterValues map[string]*string `locationName:"filterValues" type:"map"`
+	FilterValues map[string]*string `locationName:"filterValues" type:"map" sensitive:"true"`
 
 	// The item ID to provide recommendations for.
 	//
@@ -1014,7 +1014,7 @@ type Promotion struct {
 	//
 	// For more information on creating filters, see Filtering recommendations and
 	// user segments (https://docs.aws.amazon.com/personalize/latest/dg/filter.html).
-	FilterValues map[string]*string `locationName:"filterValues" type:"map"`
+	FilterValues map[string]*string `locationName:"filterValues" type:"map" sensitive:"true"`
 
 	// The name of the promotion.
 	Name *string `locationName:"name" min:"1" type:"string"`

--- a/service/pipes/api.go
+++ b/service/pipes/api.go
@@ -1005,13 +1005,13 @@ type AwsVpcConfiguration struct {
 	// must all be in the same VPC. You can specify as many as five security groups.
 	// If you do not specify a security group, the default security group for the
 	// VPC is used.
-	SecurityGroups []*string `type:"list"`
+	SecurityGroups []*string `type:"list" sensitive:"true"`
 
 	// Specifies the subnets associated with the task. These subnets must all be
 	// in the same VPC. You can specify as many as 16 subnets.
 	//
 	// Subnets is a required field
-	Subnets []*string `type:"list" required:"true"`
+	Subnets []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -1823,7 +1823,7 @@ type CreatePipeInput struct {
 	SourceParameters *PipeSourceParameters `type:"structure"`
 
 	// The list of key-value pairs to associate with the pipe.
-	Tags map[string]*string `min:"1" type:"map"`
+	Tags map[string]*string `min:"1" type:"map" sensitive:"true"`
 
 	// The ARN of the target resource.
 	//
@@ -2332,7 +2332,7 @@ type DescribePipeOutput struct {
 	StateReason *string `type:"string"`
 
 	// The list of key-value pairs to associate with the pipe.
-	Tags map[string]*string `min:"1" type:"map"`
+	Tags map[string]*string `min:"1" type:"map" sensitive:"true"`
 
 	// The ARN of the target resource.
 	Target *string `min:"1" type:"string"`
@@ -3580,7 +3580,7 @@ type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The list of key-value pairs to associate with the pipe.
-	Tags map[string]*string `locationName:"tags" min:"1" type:"map"`
+	Tags map[string]*string `locationName:"tags" min:"1" type:"map" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -4110,15 +4110,15 @@ type PipeEnrichmentHttpParameters struct {
 
 	// The headers that need to be sent as part of request invoking the API Gateway
 	// REST API or EventBridge ApiDestination.
-	HeaderParameters map[string]*string `type:"map"`
+	HeaderParameters map[string]*string `type:"map" sensitive:"true"`
 
 	// The path parameter values to be used to populate API Gateway REST API or
 	// EventBridge ApiDestination path wildcards ("*").
-	PathParameterValues []*string `type:"list"`
+	PathParameterValues []*string `type:"list" sensitive:"true"`
 
 	// The query string keys/values that need to be sent as part of request invoking
 	// the API Gateway REST API or EventBridge ApiDestination.
-	QueryStringParameters map[string]*string `type:"map"`
+	QueryStringParameters map[string]*string `type:"map" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -5179,7 +5179,7 @@ type PipeSourceSelfManagedKafkaParameters struct {
 	_ struct{} `type:"structure"`
 
 	// An array of server URLs.
-	AdditionalBootstrapServers []*string `type:"list"`
+	AdditionalBootstrapServers []*string `type:"list" sensitive:"true"`
 
 	// The maximum number of records to include in each batch.
 	BatchSize *int64 `min:"1" type:"integer"`
@@ -5932,15 +5932,15 @@ type PipeTargetHttpParameters struct {
 
 	// The headers that need to be sent as part of request invoking the API Gateway
 	// REST API or EventBridge ApiDestination.
-	HeaderParameters map[string]*string `type:"map"`
+	HeaderParameters map[string]*string `type:"map" sensitive:"true"`
 
 	// The path parameter values to be used to populate API Gateway REST API or
 	// EventBridge ApiDestination path wildcards ("*").
-	PathParameterValues []*string `type:"list"`
+	PathParameterValues []*string `type:"list" sensitive:"true"`
 
 	// The query string keys/values that need to be sent as part of request invoking
 	// the API Gateway REST API or EventBridge ApiDestination.
-	QueryStringParameters map[string]*string `type:"map"`
+	QueryStringParameters map[string]*string `type:"map" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -6313,7 +6313,7 @@ type PipeTargetRedshiftDataParameters struct {
 	// The SQL statement text to run.
 	//
 	// Sqls is a required field
-	Sqls []*string `min:"1" type:"list" required:"true"`
+	Sqls []*string `min:"1" type:"list" required:"true" sensitive:"true"`
 
 	// The name of the SQL statement. You can name the SQL statement when you create
 	// it to identify the query.
@@ -7192,11 +7192,11 @@ type SelfManagedKafkaAccessConfigurationVpc struct {
 	// groups must all be in the same VPC. You can specify as many as five security
 	// groups. If you do not specify a security group, the default security group
 	// for the VPC is used.
-	SecurityGroup []*string `type:"list"`
+	SecurityGroup []*string `type:"list" sensitive:"true"`
 
 	// Specifies the subnets associated with the stream. These subnets must all
 	// be in the same VPC. You can specify as many as 16 subnets.
-	Subnets []*string `type:"list"`
+	Subnets []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -7730,7 +7730,7 @@ type TagResourceInput struct {
 	// The list of key-value pairs associated with the pipe.
 	//
 	// Tags is a required field
-	Tags map[string]*string `locationName:"tags" min:"1" type:"map" required:"true"`
+	Tags map[string]*string `locationName:"tags" min:"1" type:"map" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/proton/api.go
+++ b/service/proton/api.go
@@ -18092,7 +18092,7 @@ type ListComponentOutputsOutput struct {
 	// An array of component Infrastructure as Code (IaC) outputs.
 	//
 	// Outputs is a required field
-	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true"`
+	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -18731,7 +18731,7 @@ type ListEnvironmentOutputsOutput struct {
 	// An array of environment outputs with detail data.
 	//
 	// Outputs is a required field
-	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true"`
+	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -19540,7 +19540,7 @@ type ListServiceInstanceOutputsOutput struct {
 	// An array of service instance Infrastructure as Code (IaC) outputs.
 	//
 	// Outputs is a required field
-	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true"`
+	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -19962,7 +19962,7 @@ type ListServicePipelineOutputsOutput struct {
 	// An array of service pipeline Infrastructure as Code (IaC) outputs.
 	//
 	// Outputs is a required field
-	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true"`
+	Outputs []*Output_ `locationName:"outputs" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -20545,7 +20545,7 @@ type NotifyResourceDeploymentStatusChangeInput struct {
 	DeploymentId *string `locationName:"deploymentId" type:"string"`
 
 	// The provisioned resource state change detail data that's returned by Proton.
-	Outputs []*Output_ `locationName:"outputs" type:"list"`
+	Outputs []*Output_ `locationName:"outputs" type:"list" sensitive:"true"`
 
 	// The provisioned resource Amazon Resource Name (ARN).
 	//

--- a/service/qconnect/api.go
+++ b/service/qconnect/api.go
@@ -7407,7 +7407,7 @@ type CreateQuickResponseInput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Connect channels this quick response applies to.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// A unique, case-sensitive identifier that you provide to ensure the idempotency
 	// of the request. If not provided, the Amazon Web Services SDK populates this
@@ -9938,7 +9938,7 @@ type GroupingConfiguration struct {
 	//    * When setting criteria to RoutingProfileArn, you need to provide a list
 	//    of ARNs of Amazon Connect routing profiles (https://docs.aws.amazon.com/connect/latest/APIReference/API_RoutingProfile.html)
 	//    as values of this parameter.
-	Values []*string `locationName:"values" type:"list"`
+	Values []*string `locationName:"values" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -12395,7 +12395,7 @@ type QuickResponseData struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The media type of the quick response content.
 	//
@@ -13067,7 +13067,7 @@ type QuickResponseSearchResultData struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The media type of the quick response content.
 	//
@@ -13297,7 +13297,7 @@ type QuickResponseSummary struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The media type of the quick response content.
 	//
@@ -16014,7 +16014,7 @@ type UpdateQuickResponseInput struct {
 
 	// The Amazon Connect contact channels this quick response applies to. The supported
 	// contact channel types include Chat.
-	Channels []*string `locationName:"channels" type:"list"`
+	Channels []*string `locationName:"channels" type:"list" sensitive:"true"`
 
 	// The updated content of the quick response.
 	Content *QuickResponseDataProvider `locationName:"content" type:"structure"`

--- a/service/quicksight/api.go
+++ b/service/quicksight/api.go
@@ -39068,16 +39068,16 @@ type CustomParameterValues struct {
 	_ struct{} `type:"structure"`
 
 	// A list of datetime-type parameter values.
-	DateTimeValues []*time.Time `type:"list"`
+	DateTimeValues []*time.Time `type:"list" sensitive:"true"`
 
 	// A list of decimal-type parameter values.
-	DecimalValues []*float64 `type:"list"`
+	DecimalValues []*float64 `type:"list" sensitive:"true"`
 
 	// A list of integer-type parameter values.
-	IntegerValues []*int64 `type:"list"`
+	IntegerValues []*int64 `type:"list" sensitive:"true"`
 
 	// A list of string-type parameter values.
-	StringValues []*string `type:"list"`
+	StringValues []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -43607,7 +43607,7 @@ type DateTimeDefaultValues struct {
 	RollingDate *RollingDateConfiguration `type:"structure"`
 
 	// The static values of the DataTimeDefaultValues.
-	StaticValues []*time.Time `type:"list"`
+	StaticValues []*time.Time `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -43820,7 +43820,7 @@ type DateTimeParameter struct {
 	// The values for the date-time parameter.
 	//
 	// Values is a required field
-	Values []*time.Time `type:"list" required:"true"`
+	Values []*time.Time `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -44259,7 +44259,7 @@ type DecimalDefaultValues struct {
 	DynamicValue *DynamicDefaultValue `type:"structure"`
 
 	// The static values of the DecimalDefaultValues.
-	StaticValues []*float64 `type:"list"`
+	StaticValues []*float64 `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -44319,7 +44319,7 @@ type DecimalParameter struct {
 	// The values for the decimal parameter.
 	//
 	// Values is a required field
-	Values []*float64 `type:"list" required:"true"`
+	Values []*float64 `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -66435,7 +66435,7 @@ type IntegerDefaultValues struct {
 	DynamicValue *DynamicDefaultValue `type:"structure"`
 
 	// The static values of the IntegerDefaultValues.
-	StaticValues []*int64 `type:"list"`
+	StaticValues []*int64 `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -66495,7 +66495,7 @@ type IntegerParameter struct {
 	// The values for the integer parameter.
 	//
 	// Values is a required field
-	Values []*int64 `type:"list" required:"true"`
+	Values []*int64 `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -88835,7 +88835,7 @@ type SemanticType struct {
 	FalseyCellValue *string `type:"string" sensitive:"true"`
 
 	// The other names or aliases for the false cell value.
-	FalseyCellValueSynonyms []*string `type:"list"`
+	FalseyCellValueSynonyms []*string `type:"list" sensitive:"true"`
 
 	// The semantic type sub type name.
 	SubTypeName *string `type:"string"`
@@ -88848,7 +88848,7 @@ type SemanticType struct {
 	TruthyCellValue *string `type:"string" sensitive:"true"`
 
 	// The other names or aliases for the true cell value.
-	TruthyCellValueSynonyms []*string `type:"list"`
+	TruthyCellValueSynonyms []*string `type:"list" sensitive:"true"`
 
 	// The semantic type name.
 	TypeName *string `type:"string"`
@@ -92597,7 +92597,7 @@ type StringDefaultValues struct {
 	DynamicValue *DynamicDefaultValue `type:"structure"`
 
 	// The static values of the DecimalDefaultValues.
-	StaticValues []*string `type:"list"`
+	StaticValues []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -92718,7 +92718,7 @@ type StringParameter struct {
 	// The values of a string parameter.
 	//
 	// Values is a required field
-	Values []*string `type:"list" required:"true"`
+	Values []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/rolesanywhere/api.go
+++ b/service/rolesanywhere/api.go
@@ -6717,7 +6717,7 @@ type UntagResourceInput struct {
 	// A list of keys. Tag keys are the unique identifiers of tags.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true"`
+	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/sesv2/api.go
+++ b/service/sesv2/api.go
@@ -20300,10 +20300,10 @@ type MessageInsightsFilters struct {
 	_ struct{} `type:"structure"`
 
 	// The recipient's email address.
-	Destination []*string `type:"list"`
+	Destination []*string `type:"list" sensitive:"true"`
 
 	// The from address used to send the message.
-	FromEmailAddress []*string `type:"list"`
+	FromEmailAddress []*string `type:"list" sensitive:"true"`
 
 	// The recipient's ISP (e.g., Gmail, Yahoo, etc.).
 	Isp []*string `type:"list"`
@@ -20320,7 +20320,7 @@ type MessageInsightsFilters struct {
 	LastEngagementEvent []*string `type:"list" enum:"EngagementEventType"`
 
 	// The subject line of the message.
-	Subject []*string `type:"list"`
+	Subject []*string `type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -6826,7 +6826,7 @@ type ListPhoneNumbersOptedOutOutput struct {
 
 	// A list of phone numbers that are opted out of receiving SMS messages. The
 	// list is paginated, and each page can contain up to 100 phone numbers.
-	PhoneNumbers []*string `locationName:"phoneNumbers" type:"list"`
+	PhoneNumbers []*string `locationName:"phoneNumbers" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -14795,7 +14795,7 @@ type DescribeGatewayInformationOutput struct {
 
 	// A NetworkInterface array that contains descriptions of the gateway network
 	// interfaces.
-	GatewayNetworkInterfaces []*NetworkInterface `type:"list"`
+	GatewayNetworkInterfaces []*NetworkInterface `type:"list" sensitive:"true"`
 
 	// A value that indicates the operating state of the gateway.
 	GatewayState *string `min:"2" type:"string"`

--- a/service/taxsettings/api.go
+++ b/service/taxsettings/api.go
@@ -2919,7 +2919,7 @@ type ListTaxRegistrationsOutput struct {
 	// for each of the linked accounts.
 	//
 	// AccountDetails is a required field
-	AccountDetails []*AccountDetails `locationName:"accountDetails" type:"list" required:"true"`
+	AccountDetails []*AccountDetails `locationName:"accountDetails" type:"list" required:"true" sensitive:"true"`
 
 	// The token to retrieve the next set of results.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`

--- a/service/verifiedpermissions/api.go
+++ b/service/verifiedpermissions/api.go
@@ -4547,7 +4547,7 @@ type BatchIsAuthorizedOutputItem struct {
 	// request.
 	//
 	// Errors is a required field
-	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true"`
+	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true" sensitive:"true"`
 
 	// The authorization request that initiated the decision.
 	//
@@ -4889,7 +4889,7 @@ type BatchIsAuthorizedWithTokenOutputItem struct {
 	// request.
 	//
 	// Errors is a required field
-	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true"`
+	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true" sensitive:"true"`
 
 	// The authorization request that initiated the decision.
 	//
@@ -5096,7 +5096,7 @@ type CognitoUserPoolConfiguration struct {
 	// Amazon Cognito user pool.
 	//
 	// Example: "ClientIds": ["&ExampleCogClientId;"]
-	ClientIds []*string `locationName:"clientIds" type:"list"`
+	ClientIds []*string `locationName:"clientIds" type:"list" sensitive:"true"`
 
 	// The type of entity that a policy store maps to groups from an Amazon Cognito
 	// user pool identity source.
@@ -5187,7 +5187,7 @@ type CognitoUserPoolConfigurationDetail struct {
 	// Example: "clientIds": ["&ExampleCogClientId;"]
 	//
 	// ClientIds is a required field
-	ClientIds []*string `locationName:"clientIds" type:"list" required:"true"`
+	ClientIds []*string `locationName:"clientIds" type:"list" required:"true" sensitive:"true"`
 
 	// The type of entity that a policy store maps to groups from an Amazon Cognito
 	// user pool identity source.
@@ -5270,7 +5270,7 @@ type CognitoUserPoolConfigurationItem struct {
 	// Example: "clientIds": ["&ExampleCogClientId;"]
 	//
 	// ClientIds is a required field
-	ClientIds []*string `locationName:"clientIds" type:"list" required:"true"`
+	ClientIds []*string `locationName:"clientIds" type:"list" required:"true" sensitive:"true"`
 
 	// The type of entity that a policy store maps to groups from an Amazon Cognito
 	// user pool identity source.
@@ -7871,7 +7871,7 @@ type GetSchemaOutput struct {
 	LastUpdatedDate *time.Time `locationName:"lastUpdatedDate" type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
 	// The namespaces of the entities referenced by this schema.
-	Namespaces []*string `locationName:"namespaces" type:"list"`
+	Namespaces []*string `locationName:"namespaces" type:"list" sensitive:"true"`
 
 	// The ID of the policy store that contains the schema.
 	//
@@ -7949,7 +7949,7 @@ type IdentitySourceDetails struct {
 	// pool that are enabled for this identity source.
 	//
 	// Deprecated: This attribute has been replaced by configuration.cognitoUserPoolConfiguration.clientIds
-	ClientIds []*string `locationName:"clientIds" deprecated:"true" type:"list"`
+	ClientIds []*string `locationName:"clientIds" deprecated:"true" type:"list" sensitive:"true"`
 
 	// The well-known URL that points to this user pool's OIDC discovery endpoint.
 	// This is a URL string in the following format. This URL replaces the placeholders
@@ -8193,7 +8193,7 @@ type IdentitySourceItemDetails struct {
 	// pool that are enabled for this identity source.
 	//
 	// Deprecated: This attribute has been replaced by configuration.cognitoUserPoolConfiguration.clientIds
-	ClientIds []*string `locationName:"clientIds" deprecated:"true" type:"list"`
+	ClientIds []*string `locationName:"clientIds" deprecated:"true" type:"list" sensitive:"true"`
 
 	// The well-known URL that points to this user pool's OIDC discovery endpoint.
 	// This is a URL string in the following format. This URL replaces the placeholders
@@ -8476,7 +8476,7 @@ type IsAuthorizedOutput struct {
 	// the slice.
 	//
 	// Errors is a required field
-	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true"`
+	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -8702,7 +8702,7 @@ type IsAuthorizedWithTokenOutput struct {
 	// the slice.
 	//
 	// Errors is a required field
-	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true"`
+	Errors []*EvaluationErrorItem `locationName:"errors" type:"list" required:"true" sensitive:"true"`
 
 	// The identifier of the principal in the ID or access token.
 	Principal *EntityIdentifier `locationName:"principal" type:"structure"`
@@ -9966,7 +9966,7 @@ type OpenIdConnectIdentityTokenConfiguration struct {
 	// The ID token audience, or client ID, claim values that you want to accept
 	// in your policy store from an OIDC identity provider. For example, 1example23456789,
 	// 2example10111213.
-	ClientIds []*string `locationName:"clientIds" type:"list"`
+	ClientIds []*string `locationName:"clientIds" type:"list" sensitive:"true"`
 
 	// The claim that determines the principal in OIDC access tokens. For example,
 	// sub.
@@ -10033,7 +10033,7 @@ type OpenIdConnectIdentityTokenConfigurationDetail struct {
 	// The ID token audience, or client ID, claim values that you want to accept
 	// in your policy store from an OIDC identity provider. For example, 1example23456789,
 	// 2example10111213.
-	ClientIds []*string `locationName:"clientIds" type:"list"`
+	ClientIds []*string `locationName:"clientIds" type:"list" sensitive:"true"`
 
 	// The claim that determines the principal in OIDC access tokens. For example,
 	// sub.
@@ -10087,7 +10087,7 @@ type OpenIdConnectIdentityTokenConfigurationItem struct {
 	// The ID token audience, or client ID, claim values that you want to accept
 	// in your policy store from an OIDC identity provider. For example, 1example23456789,
 	// 2example10111213.
-	ClientIds []*string `locationName:"clientIds" type:"list"`
+	ClientIds []*string `locationName:"clientIds" type:"list" sensitive:"true"`
 
 	// The claim that determines the principal in OIDC access tokens. For example,
 	// sub.
@@ -10936,7 +10936,7 @@ type PutSchemaOutput struct {
 	// Identifies the namespaces of the entities referenced by this schema.
 	//
 	// Namespaces is a required field
-	Namespaces []*string `locationName:"namespaces" type:"list" required:"true"`
+	Namespaces []*string `locationName:"namespaces" type:"list" required:"true" sensitive:"true"`
 
 	// The unique ID of the policy store that contains the schema.
 	//
@@ -11735,7 +11735,7 @@ type UpdateCognitoUserPoolConfiguration struct {
 
 	// The client ID of an app client that is configured for the specified Amazon
 	// Cognito user pool.
-	ClientIds []*string `locationName:"clientIds" type:"list"`
+	ClientIds []*string `locationName:"clientIds" type:"list" sensitive:"true"`
 
 	// The configuration of the user groups from an Amazon Cognito user pool identity
 	// source.
@@ -12321,7 +12321,7 @@ type UpdateOpenIdConnectIdentityTokenConfiguration struct {
 	// The ID token audience, or client ID, claim values that you want to accept
 	// in your policy store from an OIDC identity provider. For example, 1example23456789,
 	// 2example10111213.
-	ClientIds []*string `locationName:"clientIds" type:"list"`
+	ClientIds []*string `locationName:"clientIds" type:"list" sensitive:"true"`
 
 	// The claim that determines the principal in OIDC access tokens. For example,
 	// sub.

--- a/service/voiceid/api.go
+++ b/service/voiceid/api.go
@@ -8648,7 +8648,7 @@ type UntagResourceInput struct {
 	// The list of tag keys you want to remove from the specified resource.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `type:"list" required:"true"`
+	TagKeys []*string `type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -9378,13 +9378,13 @@ type DocumentVersionMetadata struct {
 	Size *int64 `type:"long"`
 
 	// The source of the document.
-	Source map[string]*string `type:"map"`
+	Source map[string]*string `type:"map" sensitive:"true"`
 
 	// The status of the document.
 	Status *string `type:"string" enum:"DocumentStatusType"`
 
 	// The thumbnail of the document.
-	Thumbnail map[string]*string `type:"map"`
+	Thumbnail map[string]*string `type:"map" sensitive:"true"`
 }
 
 // String returns the string representation.

--- a/service/workspacesweb/api.go
+++ b/service/workspacesweb/api.go
@@ -7129,7 +7129,7 @@ type CreateBrowserSettingsInput struct {
 	CustomerManagedKey *string `locationName:"customerManagedKey" min:"20" type:"string"`
 
 	// The tags to add to the browser settings resource. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -7305,7 +7305,7 @@ type CreateIdentityProviderInput struct {
 	PortalArn *string `locationName:"portalArn" min:"20" type:"string" required:"true"`
 
 	// The tags to add to the identity provider resource. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -7480,7 +7480,7 @@ type CreateIpAccessSettingsInput struct {
 
 	// The tags to add to the IP access settings resource. A tag is a key-value
 	// pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -7651,7 +7651,7 @@ type CreateNetworkSettingsInput struct {
 	SubnetIds []*string `locationName:"subnetIds" min:"2" type:"list" required:"true"`
 
 	// The tags to add to the network settings resource. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 
 	// The VPC that streaming instances will connect to.
 	//
@@ -7829,7 +7829,7 @@ type CreatePortalInput struct {
 	MaxConcurrentSessions *int64 `locationName:"maxConcurrentSessions" min:"1" type:"integer"`
 
 	// The tags to add to the web portal. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -7994,7 +7994,7 @@ type CreateTrustStoreInput struct {
 	ClientToken *string `locationName:"clientToken" min:"1" type:"string" idempotencyToken:"true"`
 
 	// The tags to add to the trust store. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -8111,7 +8111,7 @@ type CreateUserAccessLoggingSettingsInput struct {
 	KinesisStreamArn *string `locationName:"kinesisStreamArn" min:"20" type:"string" required:"true"`
 
 	// The tags to add to the user settings resource. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -8275,7 +8275,7 @@ type CreateUserSettingsInput struct {
 	PrintAllowed *string `locationName:"printAllowed" type:"string" required:"true" enum:"EnabledType"`
 
 	// The tags to add to the user settings resource. A tag is a key-value pair.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 
 	// Specifies whether the user can upload files from the local device to the
 	// streaming session.
@@ -11302,7 +11302,7 @@ type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The tags of the resource.
-	Tags []*Tag `locationName:"tags" type:"list"`
+	Tags []*Tag `locationName:"tags" type:"list" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -12497,7 +12497,7 @@ type TagResourceInput struct {
 	// The tags of the resource.
 	//
 	// Tags is a required field
-	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
+	Tags []*Tag `locationName:"tags" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.
@@ -12821,7 +12821,7 @@ type UntagResourceInput struct {
 	// The list of tag keys to remove from the resource.
 	//
 	// TagKeys is a required field
-	TagKeys []*string `location:"querystring" locationName:"tagKeys" type:"list" required:"true"`
+	TagKeys []*string `location:"querystring" locationName:"tagKeys" type:"list" required:"true" sensitive:"true"`
 }
 
 // String returns the string representation.


### PR DESCRIPTION
Applies `sensitive:true` to list/map fields with sensitive targets e.g.

```
diff --git a/service/appflow/api.go b/service/appflow/api.go
index 1399352be..1dd952812 100644
--- a/service/appflow/api.go
+++ b/service/appflow/api.go
@@ -5907,7 +5907,7 @@ type CustomAuthCredentials struct {
        _ struct{} `type:"structure"`
 
        // A map that holds custom authentication credentials.
-       CredentialsMap map[string]*string `locationName:"credentialsMap" type:"map"`
+       CredentialsMap map[string]*string `locationName:"credentialsMap" type:"map" sensitive:"true"`
 
        // The custom authentication type that the connector uses.
        //
```

Tested:

```go
package main

import (
	"fmt"

	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/service/appflow"
)

func main() {
	fmt.Println(appflow.CustomAuthCredentials{
		CredentialsMap: map[string]*string{
			"foo": aws.String("bar"),
		},
	})
}
```

Before:

```
{
  CredentialsMap: {
    foo: "bar"
  }
}
```

After:

```
{
  CredentialsMap: <sensitive>
}
```