### PR TITLE
[merge before 7/30 release] declare maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@
 
 aws-sdk-go is the v1 AWS SDK for the Go programming language.
 
-We [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025) the upcoming **end-of-support for AWS SDK for Go (v1)**. We recommend that you migrate to [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/). For dates, additional details, and information on how to migrate, please refer to the linked announcement.
+## :warning: This SDK is in maintenance mode
+
+We previously [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025)
+the upcoming **end-of-support for AWS SDK for Go (v1)**.
+
+Per that announcement, as of 7/31/2024, **the SDK has entered maintenance mode**.
+Going forward, we will limit releases to address critical bug fixes and security
+issues only. The SDK will not receive API updates for new or existing services,
+or be updated to support new regions.
+
+We recommend that you migrate to [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/).
+For additional details as well as information on how to migrate, please refer
+to the linked announcement.
 
 Jump To:
 * [Getting Started](#Getting-Started)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Going forward, we will limit releases to address critical bug fixes and security
 issues only. The SDK will not receive API updates for new or existing services,
 or be updated to support new regions.
 
+Maintenance mode will last for 1 year. After 7/31/2025, the SDK will enter end-of-support, and no updates at all will be made.
 We recommend that you migrate to [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/).
 For additional details as well as information on how to migrate, please refer
 to the linked announcement.


### PR DESCRIPTION
Adds maintenance mode announcement to the readme.

[hyperlink to md render](https://github.com/aws/aws-sdk-go/blob/d5e950bcb776482360d5934944f90a8139064d59/README.md)

We should merge **before** the final release on 7/30 such that this message is captured in the tagged version.