### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/smithytesting/xml/xmlToStruct.go
+++ b/internal/smithytesting/xml/xmlToStruct.go
@@ -137,7 +137,7 @@ func StructToXML(e *xml.Encoder, node *Node, sorted bool) error {
 	// Sort Attributes
 	attrs := node.Attr
 	if sorted {
-		sortedAttrs := make([]xml.Attr, len(attrs))
+		sortedAttrs := make([]xml.Attr, 0, len(attrs))
 		for _, k := range node.Attr {
 			sortedAttrs = append(sortedAttrs, k)
 		}

--- a/private/protocol/xml/xmlutil/xml_to_struct.go
+++ b/private/protocol/xml/xmlutil/xml_to_struct.go
@@ -130,7 +130,7 @@ func StructToXML(e *xml.Encoder, node *XMLNode, sorted bool) error {
 	// Sort Attributes
 	attrs := node.Attr
 	if sorted {
-		sortedAttrs := make([]xml.Attr, len(attrs))
+		sortedAttrs := make([]xml.Attr, 0, len(attrs))
 		for _, k := range node.Attr {
 			sortedAttrs = append(sortedAttrs, k)
 		}


### PR DESCRIPTION
**[IMPORTANT] We [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025) the upcoming end-of-support for AWS SDK for Go v1. We are no longer accepting PRs for the v1 SDK.**
