### PR TITLE
add slice size check to `unmarshaler.unmarshalList()`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* Fix an issue where `jsonutil.UnmarshalJSON()` is called with an insufficient size slice.

--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -187,9 +187,12 @@ func (u unmarshaler) unmarshalList(value reflect.Value, data interface{}, tag re
 		return fmt.Errorf("JSON value is not a list (%#v)", data)
 	}
 
-	if value.IsNil() {
-		l := len(listData)
+	if l := len(listData); value.IsNil() {
 		value.Set(reflect.MakeSlice(value.Type(), l, l))
+	} else {
+		if value.Kind() != reflect.Slice || value.Len() < len(listData) {
+			return fmt.Errorf("existing slice not big enough to hold list data (%#v)", data)
+		}
 	}
 
 	for i, c := range listData {

--- a/private/protocol/json/jsonutil/unmarshal_test.go
+++ b/private/protocol/json/jsonutil/unmarshal_test.go
@@ -149,3 +149,17 @@ func TestUnmarshalJSON_JSONNumber(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalJSON_SliceNotBigEnough(t *testing.T) {
+	type input struct {
+		ListField []*int64 `locationName:"listField" type:"list"`
+	}
+	JSON := `{"listField": [1]}`
+	value := input{
+		ListField: make([]*int64, 0),
+	}
+	err := jsonutil.UnmarshalJSON(&value, bytes.NewReader([]byte(JSON)))
+	if err == nil {
+		t.Error("expect error, got nil")
+	}
+}


### PR DESCRIPTION
**[IMPORTANT] We [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025) the upcoming end-of-support for AWS SDK for Go v1. We are no longer accepting PRs for the v1 SDK.**

resolves #5330
