### PR TITLE
Feat GetObject Version Control

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,5 @@
 ### SDK Bugs
 * Fix improper use of printf-style functions.
   * Required for Go 1.24.
+* `service/s3/s3manager`: Abort multipart download if object is modified during download
+  * Fixes [4986](https://github.com/aws/aws-sdk-go/issues/4986)

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -290,13 +290,15 @@ type downloader struct {
 	in *s3.GetObjectInput
 	w  io.WriterAt
 
-	wg sync.WaitGroup
-	m  sync.Mutex
+	wg   sync.WaitGroup
+	m    sync.Mutex
+	once sync.Once
 
 	pos        int64
 	totalBytes int64
 	written    int64
 	err        error
+	etag       string
 
 	partBodyMaxRetries int
 }
@@ -424,6 +426,9 @@ func (d *downloader) downloadChunk(chunk dlchunk) error {
 
 	// Get the next byte range of data
 	in.Range = aws.String(chunk.ByteRange())
+	if in.VersionId == nil && d.etag != "" {
+		in.IfMatch = aws.String(d.etag)
+	}
 
 	var n int64
 	var err error
@@ -466,6 +471,9 @@ func (d *downloader) tryDownloadChunk(in *s3.GetObjectInput, w io.Writer) (int64
 		return 0, err
 	}
 	d.setTotalBytes(resp) // Set total if not yet set.
+	d.once.Do(func() {
+		d.etag = aws.StringValue(resp.ETag)
+	})
 
 	var src io.Reader = resp.Body
 	if d.cfg.BufferProvider != nil {


### PR DESCRIPTION
This pr fixes #4986, which is a port from the [fix](https://github.com/aws/aws-sdk-go-v2/pull/3050) on go v2
