### PR TITLE
release v1.55.7 (2025-04-22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.55.7 (2025-04-22)
+===
+
+### SDK Bugs
+* `service/s3/s3manager`: Abort multipart download if object is modified during download
+  * Fixes [4986](https://github.com/aws/aws-sdk-go/issues/4986)
+
 Release v1.55.6 (2025-01-15)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.55.6"
+const SDKVersion = "1.55.7"


### PR DESCRIPTION
**[IMPORTANT] We [announced](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025) the upcoming end-of-support for AWS SDK for Go v1. We are no longer accepting PRs for the v1 SDK.**
